### PR TITLE
remove unused env variables from docker to avoid "env variables has w…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
       fi
       if [ "$TRAVIS_OS_NAME" == "linux" ]; then
         docker run --rm \
-          --env-file <(env | grep -iE 'NAME|DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CIRCLE|TRAVIS|APPVEYOR_|CSC_|_TOKEN|_KEY|AWS_|STRIP|BUILD_') \
+          --env-file <(env | grep -iE 'NAME|DEBUG|NODE_|ELECTRON_|YARN_|NPM_|CI|CSC_|_TOKEN|_KEY|STRIP|BUILD_') \
           --env ELECTRON_CACHE="/root/.cache/electron" \
           --env ELECTRON_BUILDER_CACHE="/root/.cache/electron-builder" \
           -v ${PWD}:/project \


### PR DESCRIPTION
…hitespaces" error