### PR TITLE
FIx non-openable links in Linux

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
   "main": "app/background.js",
   "build": {
     "appId": "com.beatplus.pronmail-desktop",
-    "publish": ["github"],
+    "publish": [
+      "github"
+    ],
     "linux": {
       "target": [
         {
@@ -99,12 +101,11 @@
     "electron-dl": "^1.9.0",
     "electron-settings": "^3.1.1",
     "electron-tabs": "^0.7.0",
-    "eslint": "^4.8.0",
     "electron-updater": "^2.10.1",
+    "eslint": "^4.8.0",
     "fs-jetpack": "^1.2.0",
     "gulp-sass": "^3.1.0",
     "minimist": "^1.2.0",
-    "open": "0.0.5",
     "sweetalert": "^1.1.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "protonmail-desktop",
   "productName": "Protonmail Desktop",
   "description": "Unofficial Electron wrapper for ProtonMail",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "Matthew Core <matcore@protonmail.com>",
     "email": "matcore@protonmail.com"

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -1,6 +1,5 @@
 const ContextMenuHandler = require('electron-context-menu-handler/context-menu-handler');
-const { ipcRenderer } = require('electron');
-const open = require('open');
+const { ipcRenderer, shell } = require('electron');
 const settings = require('electron-settings');
 
 export class Sidebar {
@@ -105,9 +104,9 @@ export class Sidebar {
     tab.tabElements.title.setAttribute('tab-id', tab.id);
     tab.webview.addEventListener('dom-ready', domReadyEvent);
     tab.webview.addEventListener('page-title-updated', () => this.onTabTitleUpdate());
-    tab.webview.addEventListener('new-window', (e) => {
-      e.preventDefault();
-      open(e.url);
+    tab.webview.addEventListener('new-window', event => {
+      event.preventDefault();
+      shell.openExternal(event.url);
     });
     require('electron-context-menu')({
       window: tab.webview,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3125,10 +3125,6 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-open@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/open/-/open-0.0.5.tgz#42c3e18ec95466b6bf0dc42f3a2945c3f0cad8fc"
-
 optimist@^0.6.1, optimist@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"


### PR DESCRIPTION
This solve #108 by using Electrons shell.openExternal instead of the `open` package. Please verify that it still works on Windows.