### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/e2e/commands.js
+++ b/e2e/commands.js
@@ -5,11 +5,11 @@ export const AddCommands = {
         .waitForVisible('button.add-account', 10000)
         .pause(500)
         .click('button.add-account')
-        .waitForVisible('.sweet-alert input[type=text]')
-        .setValue('.sweet-alert input[type=text]', accountName)
+        .waitForVisible('.swal2-input')
+        .setValue('.swal2-input', accountName)
         .pause(500)
-        .click('button.confirm')
-        .waitForVisible('.sweet-alert input[type=text]', undefined, true)
+        .click('.swal2-confirm')
+        .waitForVisible('.swal2-input', undefined, true)
     });
   },
 };

--- a/e2e/multiple-accounts.e2e.js
+++ b/e2e/multiple-accounts.e2e.js
@@ -14,10 +14,10 @@ describe('multiple accounts', function () {
     return this.app.client.waitUntilWindowLoaded()
       .then(() => this.app.client.waitForVisible('button.add-account', 10000))
       .click('button.add-account')
-      .then(() => this.app.client.waitForVisible('.sweet-alert input[type=text]'))
-      .setValue('.sweet-alert input[type=text]', accountName)
+      .then(() => this.app.client.waitForVisible('.swal2-input'))
+      .setValue('.swal2-input', accountName)
       .pause(500)
-      .click('button.confirm')
+      .click('.swal2-confirm')
       .pause(500)
       .getText('.etabs-tabs .etabs-tab-title')
       .then(text => {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "fs-jetpack": "^1.2.0",
     "gulp-sass": "^3.1.0",
     "minimist": "^1.2.0",
-    "sweetalert": "^1.1.3"
+    "sweetalert2": "^7.0.9"
   },
   "devDependencies": {
     "chai": "^4.1.0",

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -61,19 +61,18 @@ export class Sidebar {
   }
 
   addAccount() {
-    const swal = require('sweetalert');
+    const swal = require('sweetalert2');
 
     const options = {
       title: 'Account name',
       text: 'Enter the name of your ProtonMail account',
-      type: 'input',
+      input: 'text',
       confirmButtonText: 'Add account',
       showCancelButton: true,
-      allowOutsideClick: true,
     };
     const onConfirmCallback = (name) => name ? this.createTab(name) : null;
 
-    swal(options, onConfirmCallback);
+    swal(options).then((result) => onConfirmCallback(result.value));
   }
 
   createTab(name) {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,5 +1,3 @@
-@import "sweetalert/dev/sweetalert.scss";
-
 html,
 body {
     width: 100%;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4160,9 +4160,9 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-sweetalert@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/sweetalert/-/sweetalert-1.1.3.tgz#d2c31ea492b22b6a8d887aea15989a238fc084ae"
+sweetalert2@^7.0.9:
+  version "7.0.9"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-7.0.9.tgz#04ec97379d7d5c6d210b27f25453d650e5492b27"
 
 table@^4.0.1:
   version "4.0.2"


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/limonte/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/limonte/sweetalert2.svg)

4. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)