### PR TITLE
focus tabview upon browser focus

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import jetpack from 'fs-jetpack';
-import { app, Menu } from 'electron';
+import { app, Menu, ipcMain } from 'electron';
 import createWindow from './helpers/window';
 import { migrateSettings } from './migrate-settings';
 import { initiateAutoUpdater } from './auto-updater';
@@ -133,6 +133,13 @@ app.on('ready', () => {
       mainWindow.openDevTools();
     }
   });
+});
+
+ipcMain.once('listen-for-browser-window-focus', event => {
+  app.on('browser-window-focus', () => {
+    event.sender.send('browser-window-focus');
+  });
+
 });
 
 app.on('activate', () => {

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -20,6 +20,7 @@ export class Sidebar {
 
     this.addEventListenerForAddAccount();
     this.initiateTabs();
+    this.listenForBrowserWindowFocus();
   }
 
   initiateTabs() {
@@ -41,7 +42,20 @@ export class Sidebar {
         }
       });
     });
+
     settings.set('SavedTabs', postSettingsArray);
+  }
+
+  listenForBrowserWindowFocus() {
+    ipcRenderer.send('listen-for-browser-window-focus');
+
+    ipcRenderer.on('browser-window-focus', () => {
+      const activeTab = this.tabGroup.getActiveTab();
+
+      if (activeTab) {
+        activeTab.webview.focus();
+      }
+    });
   }
 
   onTabRemoved(tab) {


### PR DESCRIPTION
When focus browser window the current active
tab should be focused so the user don't need
to manually focus it again.